### PR TITLE
CI checks out the repo using a GH app token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+---
 name: ci
 
 on:
@@ -24,72 +25,68 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Read Configuration
-      uses: hashicorp/vault-action@v2.4.1
-      id: vault
-      with:
-        url: ${{ env.VAULT_ADDR }}
-        token: ${{ secrets.VAULT_TOKEN }}
-        secrets: |
-          kv/data/github  "SSH_PRIVATE_KEY"     | SSH_PRIVATE_KEY;
-
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ env.GO_VERSION }}
-
-    - name: Install dependencies
-      run: |
-          mkdir -p $HOME/.ssh
-          umask 0077 && echo -e "${SSH_PRIVATE_KEY}" > $HOME/.ssh/id_rsa
-          ssh-keyscan github.com >> $HOME/.ssh/known_hosts
-
-          git config --global url."git@github.com:".insteadOf https://github.com/
-          git config --global user.email "github-bot@aserto.com"
-          git config --global user.name "Aserto Bot"
-
-          eval `ssh-agent`
-          ssh-add $HOME/.ssh/id_rsa
-
-          go run mage.go deps
-
-    - name: Clean generated code
-      run: go run mage.go clean
-
-    - name: Generate
-      run: go run mage.go generate
-
-    - name: Commit changes
-      id: commit_changes
-      if: github.event_name == 'workflow_dispatch'
-      uses: EndBug/add-and-commit@v7
-      with:
-        default_author: github_actions
-        add: 'aserto'
-
-    - name: Dispatch to aserto-dev/ts-decision-logs if a change was committed
-      if: steps.commit_changes.outputs.committed && github.event_name == 'workflow_dispatch'
-      uses: benc-uk/workflow-dispatch@v1
-      with:
-        inputs: '{"OPENAPI_SHA": "${{ steps.commit_changes.outputs.commit_sha }}", "PROTO_REF": "${{ github.event.inputs.proto_ref }}"}'
-        ref: main
-        repo: aserto-dev/ts-decision-logs
-        token: ${{ steps.vault.outputs.READ_WRITE_TOKEN }}
-        workflow: generate
+      -
+        name: Read Configuration
+        uses: hashicorp/vault-action@v3
+        id: vault
+        with:
+          url: ${{ env.VAULT_ADDR }}
+          token: ${{ secrets.VAULT_TOKEN }}
+          secrets: |
+            kv/data/github  "READ_WRITE_TOKEN"    | READ_WRITE_TOKEN;
+      -
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_KEY }}
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      -
+        name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      -
+        name: Install dependencies
+        run: go run mage.go deps
+      -
+        name: Clean generated code
+        run: go run mage.go clean
+      -
+        name: Generate
+        run: go run mage.go generate
+      -
+        name: Commit changes
+        id: commit_changes
+        if: github.event_name == 'workflow_dispatch'
+        uses: EndBug/add-and-commit@v7
+        with:
+          default_author: github_actions
+          add: 'aserto'
+      -
+        name: Dispatch to aserto-dev/ts-decision-logs if a change was committed
+        if: steps.commit_changes.outputs.committed && github.event_name == 'workflow_dispatch'
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          inputs: '{"OPENAPI_SHA": "${{ steps.commit_changes.outputs.commit_sha }}", "PROTO_REF": "${{ github.event.inputs.proto_ref }}"}'
+          ref: main
+          repo: aserto-dev/ts-decision-logs
+          token: ${{ steps.vault.outputs.READ_WRITE_TOKEN }}
+          workflow: generate
 
   release:
     runs-on: ubuntu-latest
     needs: build
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    if: true == false #TODO: figure out how we release this.
+    if: true == false  # TODO: figure out how we release this.
     steps:
       - name: Read Configuration
-        uses: hashicorp/vault-action@v2.1.0
+        uses: hashicorp/vault-action@3
         id: vault
         with:
           url: ${{ env.VAULT_ADDR }}
@@ -98,7 +95,7 @@ jobs:
             kv/data/readme  "README_VERSION_API_KEY"    | README_VERSION_API_KEY;
             kv/data/readme  "DECISION_LOGS"             | DECISION_LOGS;
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/gitleaks-check.yml
+++ b/.github/workflows/gitleaks-check.yml
@@ -1,3 +1,4 @@
+---
 name: gitleaks-check
 
 on: [pull_request]
@@ -6,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: gitleaks-check


### PR DESCRIPTION
The app is allowed to bypass branch protection rules in the repo. This setup ensures that branch protection is enforced for human contributors, but the automated workflow can generate code and commit it to main.